### PR TITLE
Allow lowercase in hexadecimal unicode characters.

### DIFF
--- a/json-parser.xsl
+++ b/json-parser.xsl
@@ -450,7 +450,7 @@
     -->
     <xsl:function name="f:hex-digit-to-integer" as="xs:integer">
         <xsl:param name="char"/>
-        <xsl:sequence select="string-length(substring-before('0123456789ABCDEF', $char))"/>
+        <xsl:sequence select="string-length(substring-before('0123456789ABCDEF', upper-case($char)))"/>
     </xsl:function>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Some JSON contains unicode characters like `\u000a`. In order to correctly convert this, the hexadecimal code must be upper-cased.
